### PR TITLE
Allow usage of "nitroattest" as native Rust library

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -18,7 +18,7 @@ build = "build.rs"
 
 [lib]
 name = "nitroattest"
-crate-type = ["cdylib", "staticlib"]   
+crate-type = ["rlib", "cdylib", "staticlib"]   
 
 [dependencies]
 libc = "0.2.91"


### PR DESCRIPTION
I want to be able to re-export the C FFI functions as part of a bigger crate. This is impossible without the crate-type "rlib".